### PR TITLE
feat(personas): add B2B/B2C images and sync copy from Refined Personas; keep hero text placement

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,18 +290,37 @@ export default function App() {
                 </div>
                 <h3 style={{ marginTop: 0, marginBottom: 12 }}>B2B Sales Persona</h3>
                 <ul style={{ color: '#D1D5DB', lineHeight: 1.6, paddingLeft: 18 }}>
-                  <li><strong>Role:</strong> Head of Enablement / RevOps / PS Lead in SMB–Mid Market consultancies.</li>
-                  <li><strong>Goals:</strong> Ramp new hires faster; standardize delivery; reduce billable ramp time.</li>
-                  <li><strong>Pain:</strong> Fragmented learning, inconsistent quality, limited time for coaching.</li>
-                  <li><strong>Buying Drivers:</strong> Proven outcomes, time‑to‑value, easy rollout, budget‑friendly.</li>
+                  <li><strong>Role:</strong> Head of Enablement / RevOps / PS Lead in SMB–Mid‑Market Salesforce consultancies.</li>
+                  <li><strong>Goals:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Ramp new hires 2–3× faster</li>
+                      <li>Standardize delivery & quality</li>
+                      <li>Reduce billable ramp‑time & shadowing needs</li>
+                    </ul>
+                  </li>
+                  <li><strong>Pains:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Fragmented, inconsistent learning</li>
+                      <li>Expensive bench time</li>
+                      <li>Limited bandwidth for coaching/mentoring</li>
+                    </ul>
+                  </li>
+                  <li><strong>Buying Drivers:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Proven outcomes + benchmarks (time‑to‑cert, reduced ramp cost)</li>
+                      <li>Easy rollout (no heavy lift, admin‑friendly)</li>
+                      <li>Budget‑friendly vs. external trainers</li>
+                    </ul>
+                  </li>
+                  <li><strong>Preferred Proof:</strong> Case studies, peer referrals, team dashboards</li>
                 </ul>
                 <h4 style={{ marginTop: 16, marginBottom: 8 }}>B2B Sales Strategy</h4>
                 <ul style={{ color: '#D1D5DB', lineHeight: 1.6, paddingLeft: 18 }}>
-                  <li><strong>Outbound:</strong> Target SI partners, boutiques, agencies with problem‑solution messaging.</li>
-                  <li><strong>Partnerships:</strong> Community groups (Admin/Architect), events (Irish Dreamin’), podcasts.</li>
-                  <li><strong>Pilot Offers:</strong> Team trials, enablement packs, manager dashboards.</li>
-                  <li><strong>Pricing:</strong> Tiered seats with annual discounts; PO/invoice support.</li>
-                  <li><strong>KPIs:</strong> Trials→paid conversion, time‑to‑first‑cert, seat expansion, NPS.</li>
+                  <li><strong>Outbound:</strong> Target boutique SIs, agencies, and mid‑tier partners.</li>
+                  <li><strong>Partnerships:</strong> Community groups (Admin/Architect), events (Irish Dreamin’), guest podcasts/webinars.</li>
+                  <li><strong>Pilot Offers:</strong> Team trials, enablement starter packs, manager dashboards showing progress.</li>
+                  <li><strong>Pricing:</strong> Tiered seat bundles, annual discounts, PO/invoice support.</li>
+                  <li><strong>KPIs:</strong> Trial→Paid conversion, Avg. Time‑to‑First Cert, Seat Expansion, Manager NPS.</li>
                 </ul>
               </div>
 
@@ -316,18 +335,36 @@ export default function App() {
                 </div>
                 <h3 style={{ marginTop: 0, marginBottom: 12 }}>B2C Persona</h3>
                 <ul style={{ color: '#D1D5DB', lineHeight: 1.6, paddingLeft: 18 }}>
-                  <li><strong>Profile:</strong> Career switchers and junior admins/consultants pursuing certs.</li>
-                  <li><strong>Goals:</strong> Land role upgrades, pass certs, build portfolio confidence.</li>
-                  <li><strong>Pain:</strong> Info overload, expensive prep, lack of structured path.</li>
-                  <li><strong>Motivation:</strong> Community, practical guides, quick wins, mentor signals.</li>
+                  <li><strong>Profile:</strong> Career switchers + junior Admins/Consultants pursuing first or next Salesforce cert.</li>
+                  <li><strong>Goals:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Land first Salesforce role or upgrade job</li>
+                      <li>Pass Admin/Consultant certs on first attempt</li>
+                      <li>Build confidence with practical exercises & portfolio projects</li>
+                    </ul>
+                  </li>
+                  <li><strong>Pains:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Overwhelmed by scattered blogs/YouTube</li>
+                      <li>High cost of bootcamps & official prep</li>
+                      <li>Unsure if they’re “ready” for interviews/certs</li>
+                    </ul>
+                  </li>
+                  <li><strong>Motivations:</strong>
+                    <ul style={{ marginTop: 6 }}>
+                      <li>Clear, step‑by‑step study paths</li>
+                      <li>Quick wins (badges, streaks, checklists)</li>
+                      <li>Community validation + mentorship signals</li>
+                    </ul>
+                  </li>
                 </ul>
                 <h4 style={{ marginTop: 16, marginBottom: 8 }}>B2C Sales Strategy</h4>
                 <ul style={{ color: '#D1D5DB', lineHeight: 1.6, paddingLeft: 18 }}>
-                  <li><strong>Acquisition:</strong> SEO content, Learning Hub, newsletter, social micro‑demos.</li>
-                  <li><strong>Activation:</strong> Guided paths, checklists, practice exams, streaks.</li>
-                  <li><strong>Monetization:</strong> Freemium→Pro (mock exams, toolkits), student discounts.</li>
-                  <li><strong>Community:</strong> Study circles, office hours, shareable progress.</li>
-                  <li><strong>KPIs:</strong> Signup→activation, WAU, cert pass rate, retention.</li>
+                  <li><strong>Acquisition:</strong> SEO blog content, free Learning Hub, newsletter growth loops, TikTok/LinkedIn micro‑demos.</li>
+                  <li><strong>Activation:</strong> Guided learning paths, checklists, practice exams, gamified streaks.</li>
+                  <li><strong>Monetization:</strong> Freemium→Pro (mock exams, toolkits, AI‑powered study buddy), student/early‑career discounts.</li>
+                  <li><strong>Community:</strong> Peer study circles, office hours, shareable “I passed!” progress cards.</li>
+                  <li><strong>KPIs:</strong> Signup→Activation Rate, WAU, Cert Pass Rate uplift, Retention (renewals, streaks kept).</li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
- Adds image slots for Personas (B2B/B2C)\n- Syncs copy from ConsultantCloud_Refined_Personas.docx\n- Ensures hero text (Financial Dashboard / 36-Month Financial Planning & Analysis) remains directly under the hero heading\n\nNote: expects images at public/assets/persona-b2b.png and persona-b2c.png. I can attach them if you confirm filenames in Downloads.