### PR TITLE
Fix source column display in research tables

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -133,14 +133,13 @@ function SourcesTable({ title, data, compact = false }) {
           maxWidth: '100%',
           borderCollapse: 'collapse',
           color: '#E5E7EB',
-          minWidth: minTableWidth,
-          tableLayout: 'fixed'
+          minWidth: minTableWidth
         }}>
           <colgroup>
-            <col style={{ width: '8%' }} />
-            <col style={{ width: '70%' }} />
-            <col style={{ width: '16%' }} />
-            <col style={{ width: '6%' }} />
+            <col style={{ width: '10%' }} />
+            <col style={{ width: '55%' }} />
+            <col style={{ width: '25%' }} />
+            <col style={{ width: '10%' }} />
           </colgroup>
           <thead>
             <tr>
@@ -183,7 +182,7 @@ function SourcesTable({ title, data, compact = false }) {
                 }}>
                   {entry.claim}
                 </td>
-                <td style={{ padding: '12px 16px', textAlign: 'center', borderBottom: '1px solid #374151', fontSize: bodyFontSize }}>
+                <td style={{ padding: '12px 16px', textAlign: 'left', borderBottom: '1px solid #374151', fontSize: bodyFontSize, lineHeight: 1.4 }}>
                   {entry.source}
                 </td>
                 <td style={{ padding: '12px 16px', textAlign: 'center', borderBottom: '1px solid #374151', fontSize: bodyFontSize }}>


### PR DESCRIPTION
## Summary
- Fixed awkward text wrapping in SOURCE column that made it difficult to read on desktop/laptop screens
- Improved overall table layout and readability

## Changes Made
- **Removed `tableLayout: 'fixed'`** - Allows more natural column sizing
- **Increased Source column width** from 16% to 25%
- **Changed Source column alignment** from center to left for better multi-line text readability
- **Adjusted column widths**: Year: 10%, Claim: 55%, Source: 25%, Link: 10%
- **Added `lineHeight: 1.4`** to Source column for improved text spacing

## Before
Source column text was cramped and wrapping awkwardly with centered alignment, making long source names hard to read.

## After
Source column now has adequate width with left alignment for clean, readable text display on all screen sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)